### PR TITLE
OXDEV-4365 adapt require section

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,10 +5,7 @@
   "keywords": ["oxid", "modules", "eShop", "password", "password-strength", "password-policy"],
   "license": "GPL-3.0-only",
   "require": {
-    "oxid-esales/oxideshop-ce": "^v6.3"
-  },
-  "require-dev": {
-
+    "php": ">=7.0"
   },
   "extra": {
     "oxideshop": {


### PR DESCRIPTION
To require oxideshop-ce makes it very hard to install this module alongside a development version of the shop, so I suggest removing this requirement and instead only require the oldest supported php version.