### PR TITLE
fix: add missing composer dependencies to run analysis more accurately

### DIFF
--- a/.deepsource.toml
+++ b/.deepsource.toml
@@ -2,8 +2,9 @@ version = 1
 
 exclude_patterns = [
   "vendor/**",
-  "node_modules/**",
-  "parents.php"
+  "source/**",
+  "var/**",
+  "translation/**"
 ]
 
 [[analyzers]]

--- a/.deepsource.toml
+++ b/.deepsource.toml
@@ -2,7 +2,8 @@ version = 1
 
 exclude_patterns = [
   "vendor/**",
-  "node_modules/**"
+  "node_modules/**",
+  "parents.php"
 ]
 
 [[analyzers]]

--- a/.deepsource.toml
+++ b/.deepsource.toml
@@ -1,5 +1,10 @@
 version = 1
 
+exclude_patterns = [
+  "vendor/**",
+  "node_modules/**"
+]
+
 [[analyzers]]
 name = "javascript"
 enabled = true

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /.idea
 /.php_cs.cache
 /phive.phar
+/vendor/*

--- a/composer.json
+++ b/composer.json
@@ -6,11 +6,13 @@
   "license": "GPL-3.0-only",
   "require": {
     "php": ">=7.3",
-    "ext-json": "*"
+    "ext-json": "*",
+    "oxid-esales/oxideshop-ce": "^6.0"
   },
   "require-dev": {
     "php-parallel-lint/php-parallel-lint": "^1.2",
-    "oxid-esales/oxideshop-ide-helper": "^4"
+    "oxid-esales/oxideshop-ide-helper": "^4",
+    "oxid-esales/testing-library": "^8.0"
   },
   "extra": {
     "oxideshop": {

--- a/composer.json
+++ b/composer.json
@@ -6,13 +6,13 @@
   "license": "GPL-3.0-only",
   "require": {
     "php": ">=7.3",
-    "ext-json": "*",
-    "oxid-esales/oxideshop-ce": "^6.0"
+    "ext-json": "*"
   },
   "require-dev": {
     "php-parallel-lint/php-parallel-lint": "^1.2",
     "oxid-esales/oxideshop-ide-helper": "^4",
-    "oxid-esales/testing-library": "^8.0"
+    "oxid-esales/testing-library": "^8.0",
+    "oxid-esales/oxideshop-ce": "^6.4"
   },
   "extra": {
     "oxideshop": {


### PR DESCRIPTION
This PR adds missing dependencies that needs to be there in order to run this package. Currently, the package is using some classes(`OxidEsales\Eshop\Core\ViewConfig`, `OxidEsales\Eshop\Core\Registry`, etc.) which are not part of the package or it's dependencies. In order to properly resolve the symbols, it is encouraged to explicitly require the packages and mention it in `composer.json` file. This will also help DeepSource's PHP analyser to accurately run analysis.
**Note:** Please suggest the exact version number to require. For the demonstration purpose, I've included the version number which I saw.

In addition, you can use `exclude_patterns` parameter in `.deepsource.toml` file to avoid analyzing code of third party vendors. This will reduce the amount of time to run the analysis.