### PR TITLE
fixed missing question mark

### DIFF
--- a/src/Core/PasswordPolicyValidator.php
+++ b/src/Core/PasswordPolicyValidator.php
@@ -91,7 +91,7 @@ class PasswordPolicyValidator extends PasswordPolicyValidator_parent
 
         if (
             $settings->getPasswordNeedSpecialCharacter() and
-            !preg_match('([\.,_@\~\(\)\!\#\$%\^\&\*\+=\-\\\/|:;`]+)', $sPassword)
+            !preg_match('([\.,_@\~\(\)\!\#\$%\?\^\&\*\+=\-\\\/|:;`]+)', $sPassword)
         ) {
             $sError = 'OXPS_PASSWORDPOLICY_PASSWORDSTRENGTH_ERROR_REQUIRESSPECIAL';
         }


### PR DESCRIPTION
The question mark is missing in the validation of the password. The question mark is listed as a permitted special character in the error messages.